### PR TITLE
un hardcode the URL opttion + bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ Boatswain will be expanded to support arbitrary arguments in this config file
 which could save you some typing when running commands, but for now just accept
 that it's a little overkill.
 
+If you don't need either one of Canvas or GitHub integration, you can just
+answer "no" when it asks if you'd like to configure one or the other. If you
+answer "yes", make sure you have the respective auth tokens ready.
+
+When configuring Canvas, it will also ask for a URL. You should pass in the URL
+that corresponds to the host name where Canvas is hosted. For example, for
+Columbia, you should enter:
+
+    https://courseworks2.columbia.edu/
+
+If you are using a version of Canvas Wrangler from before May 14, 2019, you may
+also add the url configuration to your `boatswain.ini` manually, e.g.:
+
+    [canvas]
+    token   = <token>
+    url     = https://courseworks2.columbia.edu/
+
 
 Canvas Wrangler
 ===============

--- a/boatswain_env.py
+++ b/boatswain_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import configparser
 import os
@@ -10,6 +10,7 @@ DEFAULT_INI_PATH = os.path.expanduser('~/.boatswain.ini')
 
 CANVAS_SECTION = 'canvas'
 CANVAS_TOKEN = 'token'
+CANVAS_URL = 'url'
 
 GITHUB_SECTION = 'github'
 GITHUB_TOKEN = 'token'
@@ -248,6 +249,9 @@ def newPopulatedConfigInteractive():
                 'and clicking on "+New Access Token"')
         canvasToken = itv.promptInput('Enter Canvas auth token')
         config.set(CANVAS_SECTION, CANVAS_TOKEN, canvasToken)
+        print("read token: {}".format(canvasToken))
+        canvasUrl = itv.promptInput('Enter Canvas URL')
+        config.set(CANVAS_SECTION, CANVAS_URL, canvasUrl)
 
     i = itv.promptSelect('Configure GitHub token?', ['n'], default='y')
     if i == 'y':

--- a/boatswain_env.py
+++ b/boatswain_env.py
@@ -34,6 +34,9 @@ class BoatswainConfig(configparser.ConfigParser):
     def canvasToken(self):
         return self.get(CANVAS_SECTION, CANVAS_TOKEN)
 
+    def canvasUrl(self):
+        return self.get(CANVAS_SECTION, CANVAS_URL)
+
     def githubToken(self):
         return self.get(GITHUB_SECTION, GITHUB_TOKEN)
 
@@ -50,6 +53,11 @@ class BoatswainOption(argparse.Namespace):
         if self.canvas_token is None:
             return self.config.canvasToken()
         return self.canvas_token
+
+    def canvasUrl(self):
+        if self.canvas_url is None:
+            return self.config.canvasUrl()
+        return self.canvas_url
 
     def githubToken(self):
         if self.github_token is None:
@@ -176,12 +184,33 @@ def ParseOption(
                                 help='override Boatswain Canvas token',
                                 metavar='<canvas-token>',
             )
-        # handle incomplete config; don't handle NoSectionError because we
-        # assume that the canvas and github sections at least exist
         except configparser.NoOptionError:
+            print('[WARN]: You appear to be missing a Canvas token in your '
+                + 'Boatswain configuration ({}). Please add this information '
+                + 'to your config file under section [canvas] with key "token".'
+                + '\n'.format(config_path))
             parser.add_argument('canvas_token',
                                 type=str,
                                 help='Canvas LMS auth token',
+                                metavar='<canvas-token>',
+            )
+
+        try:
+            canvasUrl = config.canvasUrl()
+            parser.add_argument('--canvas-url',
+                                default=canvasUrl,
+                                type=str,
+                                help='override Boatswain Canvas URL',
+                                metavar='<canvas-url>',
+            )
+        except configparser.NoOptionError:
+            print('[WARN]: You appear to be missing the Canvas URL in your '
+                + 'Boatswain configuration ({}). Please add this information '
+                + 'to your config file under section [canvas] with key "url".'
+                + '\n'.format(config_path))
+            parser.add_argument('canvas_url',
+                                type=str,
+                                help='Canvas LMS URL',
                                 metavar='<canvas-token>',
             )
 
@@ -194,9 +223,11 @@ def ParseOption(
                                 help='override Boatswain GitHub token',
                                 metavar='<github-token>',
             )
-        # handle incomplete config; don't handle NoSectionError because we
-        # assume that the canvas and github sections at least exist
         except configparser.NoOptionError:
+            print('[WARN]: You appear to be missing a GitHub token in your '
+                + 'Boatswain configuration ({}). Please add this information '
+                + 'to your config file under section [github] with key "token".'
+                + '\n'.format(config_path))
             parser.add_argument('github_token',
                                 type=str,
                                 help='GitHub auth token',
@@ -242,18 +273,19 @@ def newPopulatedConfigInteractive():
     config.add_section(CANVAS_SECTION)
     config.add_section(GITHUB_SECTION)
 
-    i = itv.promptSelect('Configure Canvas token?', ['n'], default='y')
+    i = itv.promptSelect('Configure Canvas?', ['n'], default='y')
     if i == 'y':
         itv.output('You can generate a new Canvas token by going to your '
                 'Canvas Profile -> Settings -> Approved Integrations '
                 'and clicking on "+New Access Token"')
-        canvasToken = itv.promptInput('Enter Canvas auth token')
-        config.set(CANVAS_SECTION, CANVAS_TOKEN, canvasToken)
-        print("read token: {}".format(canvasToken))
+
         canvasUrl = itv.promptInput('Enter Canvas URL')
         config.set(CANVAS_SECTION, CANVAS_URL, canvasUrl)
 
-    i = itv.promptSelect('Configure GitHub token?', ['n'], default='y')
+        canvasToken = itv.promptInput('Enter Canvas auth token')
+        config.set(CANVAS_SECTION, CANVAS_TOKEN, canvasToken)
+
+    i = itv.promptSelect('Configure GitHub?', ['n'], default='y')
     if i == 'y':
         githubToken = itv.promptInput('Enter GitHub auth token')
         config.set(GITHUB_SECTION, GITHUB_TOKEN, githubToken)

--- a/boatswain_env.py
+++ b/boatswain_env.py
@@ -170,9 +170,6 @@ def ParseOption(
                         help='debug mode; enable all output',
     )
 
-    
-
-
     config = BoatswainConfig(config_path)
 
     if req_canvas:

--- a/canvas-wrangler.py
+++ b/canvas-wrangler.py
@@ -141,9 +141,7 @@ def wrangle_canvas(opt):
 
     grade_data = build_grade_data(grades, student_i, grade_i, comment_i, opt)
 
-    canvasURL = 'https://courseworks2.columbia.edu/' # TODO: don't hard
-
-    canvas = Canvas(canvasURL, opt.canvasToken())
+    canvas = Canvas(opt.canvasUrl(), opt.canvasToken())
     course = canvas.get_course(opt.course_id)
     assignment = course.get_assignment(opt.assignment_id)
 

--- a/interactive.py
+++ b/interactive.py
@@ -17,7 +17,6 @@ def promptInput(prompt, fmt='', default=''):
 
     while True:
         inp = input(promptf)
-        inp = inp.lower()
         if inp != '':
             return inp
         elif default != '' and inp == '':
@@ -33,6 +32,18 @@ def promptValidate(prompt, validator, fmt='', default=''):
         if v == '':
             return inp
         output('Invalid input (case-insensitive): {}'.format(v))
+
+
+def selectorValidator(options, default=''):
+    def validator(inp):
+        i = inp.lower()
+        if default != '':
+            if i == default.lower() or i == '':
+                return ''
+        if i in options:
+            return ''
+        return i
+    return validator
 
 
 '''
@@ -52,18 +63,7 @@ def promptSelect(prompt, alts, default=''):
     validator = selectorValidator(options, default=default)
     inp = promptValidate(prompt, validator, fmt=fmt, default=default)
 
-    return inp
-
-
-def selectorValidator(options, default=''):
-    def validator(inp):
-        if default != '':
-            if inp == default.lower() or inp == '':
-                return ''
-        if inp in options:
-            return ''
-        return inp
-    return validator
+    return inp.lower()
 
 
 def newFileValidator():


### PR DESCRIPTION
two new features:
- `boatswain_env.py`  no longer tries to set your auth tokens to lower case, so that no longer breaks
- the canvas url is no longer hard coded into `canvas-wrangler.py`

admittedly this should be 2 separate commits but alas