### PR TITLE
Dependency fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Let's install all the dependencies the right way.
 Make sure you have Python3 and [`virtualenv`][venv] installed. Clone this repo.
 In the repo directory, create a virtual environment with the following command:
 
-    $ virtualenv venv
+    $ python3 -m venv venv
 
 `venv` could have been any path name, but we're going to assume that you used
 `venv`, and proceed. You should see a directory named `venv` created, and now

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,2 @@
-canvasapi==0.11.0
-certifi==2018.8.24
-chardet==3.0.4
-idna==2.7
-PyGithub==1.40
-PyJWT==1.6.4
-pytz==2018.9
-requests==2.20.0
-six==1.12.0
-urllib3==1.26.5
+canvasapi==3.0.0
+PyGithub==1.55


### PR DESCRIPTION
Resolves #15, supersedes #17

I went through the scripts manually and verified that the Canvas and Github updates didn't have any breaking changes (at least in terms of function signature), as I don't really have a way to test this atm.

`requirements.txt` only lists the explicit dependencies now (PyGithub and canvasapi) - this should allow us to use updated versions of their dependencies. I'm not convinced that pinning to (for example) canvasapi 3.0.0 is the correct approach, as presumably we would want to use version 3.0.1, etc.