### PR TITLE
Updated depricated argparse fileType parameter for new Python versions

### DIFF
--- a/add_collaborators.py
+++ b/add_collaborators.py
@@ -23,7 +23,7 @@ def add_collaborators_deco(parser):
     )
 
     parser.add_argument('users',
-                        type=argparse.FileType('rU'),
+                        type=argparse.FileType('r'),
                         help='path of list of users to be added',
                         metavar='<users.txt>',
     )

--- a/add_team_members.py
+++ b/add_team_members.py
@@ -23,7 +23,7 @@ def add_team_members_deco(parser):
     )
 
     parser.add_argument('users',
-                        type=argparse.FileType('rU'),
+                        type=argparse.FileType('r'),
                         help='path of list of users to be added',
                         metavar='<users.txt>',
     )

--- a/mk_group_repos.py
+++ b/mk_group_repos.py
@@ -26,7 +26,7 @@ def mk_group_repos_deco(parser):
     )
 
     parser.add_argument('groups',
-                        type=argparse.FileType('rU'),
+                        type=argparse.FileType('r'),
                         help='path of list of groups (group,[member,])',
                         metavar='<groups.csv>',
     )


### PR DESCRIPTION
For new versions of Python, this argparse command needs to be updated from using rU to r as a parameter for the fileType. It seems to have been deprecated. Boatswain was not working on my computer using Python version 3.11.4.

![image](https://github.com/cs3157/boatswain/assets/48461874/cd462945-55c9-4600-9ff1-fc88d956ae24)

https://stackoverflow.com/questions/56791545/what-is-the-non-deprecated-version-of-open-u-mode
